### PR TITLE
Match route to request

### DIFF
--- a/src/WP_Route.php
+++ b/src/WP_Route.php
@@ -129,7 +129,25 @@ final class WP_Route{
     	}
     	
     	return $return;
-    }
+	}
+	
+	private function matchRouteToRequest($route, $request) {
+		$routes = $this->tokenize($route);
+		$requests = $this->tokenize($request);
+	  
+		$diff = array_diff($routes, $requests);
+		
+		$matched = true;
+	  
+		if( !empty($diff) ) {
+		  foreach($diff as $k => $param) {
+			if( preg_match('/\{\s*.+?\s*\}/', $param) && !empty($requests[$k]) ) continue;
+			$matched = false;
+		  }
+		}
+	  
+		return $matched;
+	}
 
 
     // -----------------------------------------------------
@@ -162,7 +180,13 @@ final class WP_Route{
     		if(count($this->tokenize($route->route)) !== count($tokenizedRequestURI)){
     			unset($routes[$key]);
     			continue;
-    		}
+			}
+			
+			// Filter routes that do not match the request
+			if( ! $this->matchRouteToRequest($route->route, $requestURI) ) {
+				unset($routes[$key]);
+				continue;
+			}
 
     		// Add more filtering here as routing gets more complex.
     	}


### PR DESCRIPTION
## Problem:

Defined route: 

`WP_Route::get('flights', 'callbackFn');`

Any of the following request URIs will match with the above route definition and 'callbackFn' get fired:
***"/flight"***, ***"/anytext"***, ***"/tttttttt"***, ***"eeee"*** ...etc

## Fix:

An additional utility method called ***"matchRouteToRequest"*** has been added. Then, we add a filter inside the 'handler' to filter-out the routes with a pattern that do not match the requested URI.