### PR TITLE
Check that routes actually equal

### DIFF
--- a/src/WP_Route.php
+++ b/src/WP_Route.php
@@ -165,10 +165,10 @@ final class WP_Route{
     			continue;
     		}
     		
-    		foreach ($tokenizedRoute as $i => $segment) {
-	    		if (!preg_match('/^\{.*}$/', $segment) && $segment !== $tokenizedRequestURI[$i]) {
-					unset($routes[$key]);
-					continue 2;
+    		foreach($tokenizedRoute as $i => $segment){
+	    		if(!preg_match('/^\{.*\}$/', $segment) && $segment !== $tokenizedRequestURI[$i]){
+				unset($routes[$key]);
+				continue 2;
 	    		}
     		}
 

--- a/src/WP_Route.php
+++ b/src/WP_Route.php
@@ -159,9 +159,17 @@ final class WP_Route{
 
     	foreach($routes as $key => $route){
     		// First, filter routes that do not have equal tokenized lengths
-    		if(count($this->tokenize($route->route)) !== count($tokenizedRequestURI)){
+    		$tokenizedRoute = $this->tokenize($route->route);
+    		if(count($tokenizedRoute) !== count($tokenizedRequestURI)){
     			unset($routes[$key]);
     			continue;
+    		}
+    		
+    		foreach ($tokenizedRoute as $i => $segment) {
+	    		if (!preg_match('/^\{.*}$/', $segment) && $segment !== $tokenizedRequestURI[$i]) {
+					unset($routes[$key]);
+					continue 2;
+	    		}
     		}
 
     		// Add more filtering here as routing gets more complex.


### PR DESCRIPTION
We discovered that when you register a handler for a path this plugin invokes it for all paths that have euqal amount of segments.

Ie: you register `/bar/{foo}` but the plugin invokes the handler for `/*/{foo}`.

This PR fixes that.